### PR TITLE
JSON Producer

### DIFF
--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaProducerConfig.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaProducerConfig.java
@@ -1,5 +1,6 @@
 package com.ittovative.demodbtokafka.config;
 
+import com.ittovative.demodbtokafka.entity.Student;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,7 +32,7 @@ public class KafkaProducerConfig {
      * @return the kafka template
      */
     @Bean
-    public KafkaTemplate<String, String> studentKafkaTemplate() {
+    public KafkaTemplate<String, Student> studentKafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 
@@ -41,7 +42,7 @@ public class KafkaProducerConfig {
      * @return the producer factory
      */
     @Bean
-    public ProducerFactory<String, String> producerFactory() {
+    public ProducerFactory<String, Student> producerFactory() {
         Map<String, Object> configProps = new HashMap<>();
 
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/Producer.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/Producer.java
@@ -3,7 +3,7 @@ package com.ittovative.demodbtokafka.constant;
 public final class Producer {
     public static final String BOOTSTRAP_SERVERS = "localhost:19092";
     public static final String KEY_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
-    public static final String VALUE_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+    public static final String VALUE_SERIALIZER = "org.springframework.kafka.support.serializer.JsonSerializer";
     public static final String ACKS = "all";
     public static final Integer RETRIES = 0;
     public static final Integer BATCH_SIZE = 16384;

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/service/StudentServiceImpl.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/service/StudentServiceImpl.java
@@ -13,10 +13,10 @@ import java.util.Optional;
 class StudentServiceImpl implements StudentService {
 
     private final StudentRepository studentRepository;
-    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final KafkaTemplate<String, Student> kafkaTemplate;
 
     @Autowired
-    StudentServiceImpl(StudentRepository studentRepository, KafkaTemplate<String, String> kafkaTemplate) {
+    StudentServiceImpl(StudentRepository studentRepository, KafkaTemplate<String, Student> kafkaTemplate) {
         this.studentRepository = studentRepository;
         this.kafkaTemplate = kafkaTemplate;
     }
@@ -43,7 +43,6 @@ class StudentServiceImpl implements StudentService {
 
     @Override
     public void sendToKafka(Student student) {
-        kafkaTemplate.send("student",
-                "Welcome " + student.getFirstName() + " " + student.getLastName() + " to Kafka.");
+        kafkaTemplate.send("student", student);
     }
 }


### PR DESCRIPTION
# Changelog
- Use JSON producer instead of String to be able to read student data more easily from the second demo.