### PR TITLE
Send Batche of Students Instead of One Student

### DIFF
--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaProducerConfig.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaProducerConfig.java
@@ -27,7 +27,7 @@ import static com.ittovative.demodbtokafka.constant.Producer.VALUE_SERIALIZER;
 @Configuration
 public class KafkaProducerConfig {
     /**
-     * KafkaTemplate for student.
+     * KafkaTemplate for student which is used to students to Kafka topic.
      *
      * @return the kafka template
      */

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/Producer.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/Producer.java
@@ -7,7 +7,7 @@ public final class Producer {
     public static final String ACKS = "all";
     public static final Integer RETRIES = 0;
     public static final Integer BATCH_SIZE = 16384;
-    public static final Integer LINGER_MS = 1;
+    public static final Integer LINGER_MS = 100;
     public static final Integer BUFFER_MEMORY = 33554432;
 
     private Producer() {

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/controller/StudentController.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/controller/StudentController.java
@@ -6,11 +6,12 @@ import com.ittovative.demodbtokafka.util.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 /**
- * Student controller for sending students to Kafka.
+ * Student controller for sending batch of students.
  */
 @RestController
 public class StudentController {
@@ -21,19 +22,18 @@ public class StudentController {
     }
 
     /**
-     * Get student from database and send him to Kafka Topic.
+     * Gets batch of students to kafka.
      *
-     * @param id the id
-     * @return response of sending a student to Kafka
+     * @return the student batch to kafka
      */
-    @GetMapping("/students/kafka/{id}")
-    public ResponseEntity<ApiResponse<Student>> getStudentToKafka(@PathVariable("id") Integer id) {
-        Student student = studentService.findById(id);
+    @GetMapping("/students/kafka")
+    public ResponseEntity<ApiResponse<Student>> getStudentBatchToKafka() {
+        List<Student> students = studentService.findAll();
 
-        studentService.sendToKafka(student);
+        studentService.sendBatchToKafka(students);
 
         ApiResponse<Student> apiResponse =
-                new ApiResponse<>(null, HttpStatus.OK.value(), "Send Student " + id + " to Kafka");
+                new ApiResponse<>(null, HttpStatus.OK.value(), "Students batch sent to Kafka");
         return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 }

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/service/StudentService.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/service/StudentService.java
@@ -6,10 +6,9 @@ import java.util.List;
 
 
 /**
- * The interface Student service for finding all students or one student by id.
+ * The interface Student service for getting all students sending them to Kafka.
  */
 public interface StudentService {
-
     /**
      * Get all students.
      *
@@ -18,17 +17,9 @@ public interface StudentService {
     List<Student> findAll();
 
     /**
-     * Find student by its id .
+     * Send list of students in a batch to Kafka topic.
      *
-     * @param id the id of the student
-     * @return the student with the specified id
+     * @param students list of students to send in batch
      */
-    Student findById(Integer id);
-
-    /**
-     * Send student to Kafka Topic.
-     *
-     * @param student the student
-     */
-    void sendToKafka(Student student);
+    void sendBatchToKafka(List<Student> students);
 }

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/service/StudentServiceImpl.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/service/StudentServiceImpl.java
@@ -7,7 +7,6 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 class StudentServiceImpl implements StudentService {
@@ -27,22 +26,9 @@ class StudentServiceImpl implements StudentService {
     }
 
     @Override
-    public Student findById(Integer id) {
-        Optional<Student> result = studentRepository.findById(id);
-
-        Student student = null;
-
-        if (result.isPresent()) {
-            student = result.get();
-        } else {
-            throw new RuntimeException("Couldn't find student with id " + id);
+    public void sendBatchToKafka(List<Student> students) {
+        for (Student student : students) {
+            kafkaTemplate.send("student", student);
         }
-
-        return student;
-    }
-
-    @Override
-    public void sendToKafka(Student student) {
-        kafkaTemplate.send("student", student);
     }
 }


### PR DESCRIPTION
# Changelog
- Remove sending one student to kafka service and controller.
- Change `LINGER_MS` time to 100 to enable producer to send in batches.
- Add controller and service for sending batches of students at `localhost:8080/students/kafka`.