### PR TITLE
Consume Students From Kafka Topic and Insert Them To Database

### DIFF
--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaProducerConfig.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaProducerConfig.java
@@ -20,22 +20,11 @@ import static com.ittovative.demodbtokafka.constant.Producer.LINGER_MS;
 import static com.ittovative.demodbtokafka.constant.Producer.RETRIES;
 import static com.ittovative.demodbtokafka.constant.Producer.VALUE_SERIALIZER;
 
-
 /**
  * Configuration for the Kafka producer.
  */
 @Configuration
 public class KafkaProducerConfig {
-    /**
-     * KafkaTemplate for student which is used to students to Kafka topic.
-     *
-     * @return the kafka template
-     */
-    @Bean
-    public KafkaTemplate<String, Student> studentKafkaTemplate() {
-        return new KafkaTemplate<>(producerFactory());
-    }
-
     /**
      * Create and configure a Producer.
      *
@@ -55,5 +44,15 @@ public class KafkaProducerConfig {
         configProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, BUFFER_MEMORY);
 
         return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    /**
+     * KafkaTemplate for student which is used to students to Kafka topic.
+     *
+     * @return the kafka template
+     */
+    @Bean
+    public KafkaTemplate<String, Student> studentKafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/Producer.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/Producer.java
@@ -2,7 +2,7 @@ package com.ittovative.demodbtokafka.constant;
 
 public final class Producer {
     public static final String KEY_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
-    public static final String VALUE_SERIALIZER = "org.springframework.kafka.support.serializer.JsonSerializer";
+    public static final String VALUE_SERIALIZER = "com.ittovative.demodbtokafka.serializer.StudentSerializer";
     public static final String ACKS = "all";
     public static final Integer RETRIES = 0;
     public static final Integer BATCH_SIZE = 16384;

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/serializer/StudentSerializer.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/serializer/StudentSerializer.java
@@ -1,0 +1,19 @@
+package com.ittovative.demodbtokafka.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ittovative.demodbtokafka.entity.Student;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class StudentSerializer implements Serializer<Student> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public byte[] serialize(String topic, Student student) {
+        try {
+            return objectMapper.writeValueAsBytes(student);
+        } catch (Exception e) {
+            throw new RuntimeException("Error serializing Student", e);
+        }
+    }
+}

--- a/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/config/KafkaConsumerConfig.java
+++ b/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/config/KafkaConsumerConfig.java
@@ -1,0 +1,56 @@
+package com.ittovative.demokafkatodb.config;
+
+import com.ittovative.demokafkatodb.deserializer.StudentDeserializer;
+import com.ittovative.demokafkatodb.entity.Student;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.ittovative.demokafkatodb.constant.Consumer.GROUP_ID;
+import static com.ittovative.demokafkatodb.constant.Kafka.BOOTSTRAP_SERVERS;
+
+/**
+ * Create and configure consumer to get students from Kafka.
+ */
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+    /**
+     * Consumer configuration.
+     *
+     * @return the consumer factory
+     */
+    @Bean
+    public ConsumerFactory<String, Student> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StudentDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    /**
+     * Use consumer factory to listen on topics.
+     *
+     * @return the concurrent kafka listener container factory
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Student> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Student> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/constant/Consumer.java
+++ b/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/constant/Consumer.java
@@ -1,0 +1,8 @@
+package com.ittovative.demokafkatodb.constant;
+
+public final class Consumer {
+    public static final String GROUP_ID = "1";
+
+    private Consumer() {
+    }
+}

--- a/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/constant/Kafka.java
+++ b/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/constant/Kafka.java
@@ -1,0 +1,8 @@
+package com.ittovative.demokafkatodb.constant;
+
+public final class Kafka {
+    public static final String BOOTSTRAP_SERVERS = "localhost:19092";
+
+    private Kafka() {
+    }
+}

--- a/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/deserializer/StudentDeserializer.java
+++ b/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/deserializer/StudentDeserializer.java
@@ -1,0 +1,19 @@
+package com.ittovative.demokafkatodb.deserializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ittovative.demokafkatodb.entity.Student;
+import org.apache.kafka.common.serialization.Deserializer;
+
+public class StudentDeserializer implements Deserializer<Student> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Student deserialize(String topic, byte[] data) {
+        try {
+            return objectMapper.readValue(data, Student.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Error deserializing Student", e);
+        }
+    }
+}

--- a/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/entity/Student.java
+++ b/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/entity/Student.java
@@ -1,0 +1,66 @@
+package com.ittovative.demokafkatodb.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "student")
+public class Student {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    public Student() {
+
+    }
+
+    public Student(Integer id, String firstName, String lastName) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    @Override
+    public String toString() {
+        return "Student{"
+                + "id=" + id
+                + ", firstName='" + firstName + '\''
+                + ", lastName='" + lastName + '\''
+                + '}';
+    }
+}

--- a/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/repository/StudentRepository.java
+++ b/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/repository/StudentRepository.java
@@ -1,0 +1,7 @@
+package com.ittovative.demokafkatodb.repository;
+
+import com.ittovative.demokafkatodb.entity.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentRepository extends JpaRepository<Student, Integer> {
+}

--- a/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/service/StudentService.java
+++ b/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/service/StudentService.java
@@ -1,0 +1,24 @@
+package com.ittovative.demokafkatodb.service;
+
+import com.ittovative.demokafkatodb.entity.Student;
+
+/**
+ * The interface Student service for saving students from Kafka topic into database.
+ */
+public interface StudentService {
+    /**
+     * Save student.
+     *
+     * @param student which will be saved to database.
+     * @return the student
+     */
+    Student save(Student student);
+
+
+    /**
+     * Save students from Kafka into database.
+     *
+     * @param student the student we will receive from Kafka topic and save to database.
+     */
+    void saveFromKafka(Student student);
+}

--- a/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/service/StudentServiceImpl.java
+++ b/demo-kafka-to-db/src/main/java/com/ittovative/demokafkatodb/service/StudentServiceImpl.java
@@ -1,0 +1,31 @@
+package com.ittovative.demokafkatodb.service;
+
+import com.ittovative.demokafkatodb.entity.Student;
+import com.ittovative.demokafkatodb.repository.StudentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+
+@EnableKafka
+@Service
+class StudentServiceImpl implements StudentService {
+    private final StudentRepository studentRepository;
+
+    @Autowired
+    StudentServiceImpl(StudentRepository studentRepository) {
+        this.studentRepository = studentRepository;
+    }
+
+    @Override
+    public Student save(Student student) {
+        return studentRepository.save(student);
+    }
+
+    @Override
+    @KafkaListener(topics = "student", groupId = "1")
+    public void saveFromKafka(Student student) {
+        studentRepository.save(student);
+    }
+}

--- a/demo-kafka-to-db/src/main/resources/application.yaml
+++ b/demo-kafka-to-db/src/main/resources/application.yaml
@@ -3,3 +3,5 @@ spring:
     url: jdbc:mysql://localhost:3306/destination
     username: root
     password: password
+server:
+  port: 8081


### PR DESCRIPTION
# Changelog
- Add student entity, repository, and service.
- Implement consumer and consume from topic "student".
- Send students data to "destination" database.
- Change second demo port to `8081` so that it doesn't clash with first demo at `8080`.
- Create serializer for `db-to-kafka` demo (producer).
- Create deserializer for `kafka-to-db` demo (consumer).