### PR TITLE
Refactor `constant` package

### DIFF
--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaProducerConfig.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaProducerConfig.java
@@ -11,14 +11,14 @@ import org.springframework.kafka.core.ProducerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.ittovative.demodbtokafka.constant.Kafka.BOOTSTRAP_SERVERS;
-import static com.ittovative.demodbtokafka.constant.Producer.ACKS;
-import static com.ittovative.demodbtokafka.constant.Producer.BATCH_SIZE;
-import static com.ittovative.demodbtokafka.constant.Producer.BUFFER_MEMORY;
-import static com.ittovative.demodbtokafka.constant.Producer.KEY_SERIALIZER;
-import static com.ittovative.demodbtokafka.constant.Producer.LINGER_MS;
-import static com.ittovative.demodbtokafka.constant.Producer.RETRIES;
-import static com.ittovative.demodbtokafka.constant.Producer.VALUE_SERIALIZER;
+import static com.ittovative.demodbtokafka.constant.KafkaConstant.BOOTSTRAP_SERVERS;
+import static com.ittovative.demodbtokafka.constant.ProducerConstant.ACKS;
+import static com.ittovative.demodbtokafka.constant.ProducerConstant.BATCH_SIZE;
+import static com.ittovative.demodbtokafka.constant.ProducerConstant.BUFFER_MEMORY;
+import static com.ittovative.demodbtokafka.constant.ProducerConstant.KEY_SERIALIZER;
+import static com.ittovative.demodbtokafka.constant.ProducerConstant.LINGER_MS;
+import static com.ittovative.demodbtokafka.constant.ProducerConstant.RETRIES;
+import static com.ittovative.demodbtokafka.constant.ProducerConstant.VALUE_SERIALIZER;
 
 /**
  * Configuration for the Kafka producer.

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaTopicConfig.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/config/KafkaTopicConfig.java
@@ -9,7 +9,8 @@ import org.springframework.kafka.core.KafkaAdmin;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.ittovative.demodbtokafka.constant.Kafka.BOOTSTRAP_SERVERS;
+import static com.ittovative.demodbtokafka.constant.KafkaConstant.BOOTSTRAP_SERVERS;
+import static com.ittovative.demodbtokafka.constant.KafkaConstant.TOPIC;
 
 /**
  * Configuration of creating Kafka topics.
@@ -38,6 +39,6 @@ public class KafkaTopicConfig {
      */
     @Bean
     public NewTopic studentTopic() {
-        return new NewTopic("student", 1, (short) 1);
+        return new NewTopic(TOPIC, 1, (short) 1);
     }
 }

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/KafkaConstant.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/KafkaConstant.java
@@ -1,8 +1,9 @@
 package com.ittovative.demodbtokafka.constant;
 
-public final class Kafka {
+public final class KafkaConstant {
     public static final String BOOTSTRAP_SERVERS = "localhost:19092";
+    public static final String TOPIC = "studen";
 
-    private Kafka() {
+    private KafkaConstant() {
     }
 }

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/ProducerConstant.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/ProducerConstant.java
@@ -1,6 +1,6 @@
 package com.ittovative.demodbtokafka.constant;
 
-public final class Producer {
+public final class ProducerConstant {
     public static final String KEY_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
     public static final String VALUE_SERIALIZER = "com.ittovative.demodbtokafka.serializer.StudentSerializer";
     public static final String ACKS = "all";
@@ -9,6 +9,6 @@ public final class Producer {
     public static final Integer LINGER_MS = 1000;
     public static final Integer BUFFER_MEMORY = 33554432;
 
-    private Producer() {
+    private ProducerConstant() {
     }
 }

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/SchedulerConstant.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/constant/SchedulerConstant.java
@@ -1,9 +1,9 @@
 package com.ittovative.demodbtokafka.constant;
 
-public final class Scheduler {
+public final class SchedulerConstant {
     public static final int FIXED_DELAY = 200;
 
-    private Scheduler() {
+    private SchedulerConstant() {
 
     }
 }

--- a/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/service/StudentServiceImpl.java
+++ b/demo-db-to-kafka/src/main/java/com/ittovative/demodbtokafka/service/StudentServiceImpl.java
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
-import static com.ittovative.demodbtokafka.constant.Scheduler.FIXED_DELAY;
+import static com.ittovative.demodbtokafka.constant.KafkaConstant.TOPIC;
+import static com.ittovative.demodbtokafka.constant.SchedulerConstant.FIXED_DELAY;
 
 @Service
 @EnableScheduling
@@ -45,6 +46,6 @@ class StudentServiceImpl implements StudentService {
     @Override
     @Scheduled(fixedDelay = FIXED_DELAY)
     public void sendToKafka() {
-        kafkaTemplate.send("student", findById(studentId++));
+        kafkaTemplate.send(TOPIC, findById(studentId++));
     }
 }

--- a/demo-db-to-kafka/src/test/java/com/ittovative/demodbtokafka/service/StudentServiceTest.java
+++ b/demo-db-to-kafka/src/test/java/com/ittovative/demodbtokafka/service/StudentServiceTest.java
@@ -15,13 +15,14 @@ import org.springframework.kafka.core.KafkaTemplate;
 
 import java.util.Optional;
 
+import static com.ittovative.demodbtokafka.constant.KafkaConstant.TOPIC;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -56,8 +57,8 @@ class StudentServiceTest {
         @Test
         @DisplayName("Find student when student exists")
         void Should_FindStudent_When_StudentExists() {
-            when(studentRepository.findById(expectedId)).thenReturn(Optional.of(actualStudent));
-            studentService.findById(expectedId);
+            when(studentRepository.findById(anyInt())).thenReturn(Optional.of(actualStudent));
+            studentService.findById(anyInt());
 
             assertAll("Assert it's exactly the same student",
                     () -> assertNotNull(actualStudent, "Student is null"),
@@ -65,16 +66,16 @@ class StudentServiceTest {
                     () -> assertEquals(expectedFirstName, actualStudent.getFirstName(), "First name mismatch"),
                     () -> assertEquals(expectedLastName, actualStudent.getLastName(), "Last name mismatch")
             );
-            verify(studentRepository, times(1)).findById(expectedId);
+            verify(studentRepository, times(1)).findById(anyInt());
         }
 
         @Test
         @DisplayName("Throw exception when student does not exist")
         void Should_ThrowException_When_StudentDoesNotExist() {
 
-            when(studentRepository.findById(expectedId)).thenReturn(Optional.empty());
+            when(studentRepository.findById(anyInt())).thenReturn(Optional.empty());
             assertThrows(StudentNotFoundException.class, () -> studentService.findById(expectedId));
-            verify(studentRepository, times(1)).findById(expectedId);
+            verify(studentRepository, times(1)).findById(anyInt());
         }
     }
 
@@ -87,17 +88,17 @@ class StudentServiceTest {
             when(studentRepository.findById(1)).thenReturn(Optional.of(actualStudent));
             studentService.sendToKafka();
 
-            verify(kafkaTemplate, times(1)).send(eq("student"), eq(actualStudent));
+            verify(kafkaTemplate, times(1)).send(TOPIC, actualStudent);
             verify(studentRepository, times(1)).findById(1);
         }
 
         @Test
         @DisplayName("Throw exception when student does not exist")
         void Should_ThrowException_When_StudentDoesNotExist() {
-            when(studentRepository.findById(expectedId)).thenReturn(Optional.empty());
+            when(studentRepository.findById(anyInt())).thenReturn(Optional.empty());
 
             assertThrows(StudentNotFoundException.class, () -> studentService.sendToKafka());
-            verify(studentRepository, times(1)).findById(expectedId);
+            verify(studentRepository, times(1)).findById(anyInt());
             verify(kafkaTemplate, never()).send(anyString(), any(Student.class));
         }
     }


### PR DESCRIPTION
# Changelog
- Change naming convention for constant files (e.g. `Producer` to `ProducerConstant`)
- Use `anyInt()` in some tests.